### PR TITLE
Feature/meanscaling

### DIFF
--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -133,7 +133,7 @@ From there, we can compute the mean posterior solution and determine
 its covariance:
 
 .. literalinclude:: ../../stat_fem/examples/poisson.py
-   :lines: 108-120
+   :lines: 108-124
 
 The script also makes some plots if Matplotlib is installed. These are
 reproduced below to show the expected output of the calculations if

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ import setuptools
 
 # version information
 MAJOR = 0
-MINOR = 1
+MINOR = 2
 MICRO = 0
-PRERELEASE = 2
+PRERELEASE = 0
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 

--- a/stat_fem/LinearSolver.py
+++ b/stat_fem/LinearSolver.py
@@ -272,7 +272,7 @@ class LinearSolver(object):
 
             tmp_meshspace_1 = solve_forcing_covariance(self.G, self.A, tmp_meshspace_1)._scale(rho**2)
 
-            x.assign((tmp_meshspace_2 - tmp_meshspace_1).scale(scalefact).function)
+            x.assign((tmp_meshspace_2 - tmp_meshspace_1)._scale(scalefact).function)
 
 
     def solve_posterior_covariance(self, scale_mean=False):
@@ -639,9 +639,9 @@ class LinearSolver(object):
 
             deriv = np.zeros(3)
 
-            deriv[0] = (-np.dot(self.mu, invKCudata) -
-                        rho*np.linalg.multi_dot([invKCudata, self.Cu, invKCudata]) +
-                        rho*np.trace(cho_solve(L, self.Cu)))
+            deriv[0] = (-rho*np.dot(self.mu, invKCudata) -
+                        rho**2*np.linalg.multi_dot([invKCudata, self.Cu, invKCudata]) +
+                        rho**2*np.trace(cho_solve(L, self.Cu)))
             for i in range(0, 2):
                 deriv[i + 1] = -0.5*(np.linalg.multi_dot([invKCudata, K_deriv[i], invKCudata]) -
                                     np.trace(cho_solve(L, K_deriv[i])))

--- a/stat_fem/examples/poisson.py
+++ b/stat_fem/examples/poisson.py
@@ -113,10 +113,14 @@ print(np.array([rho, sigma_eta, l_eta]))
 muy = Function(V)
 
 # solve_posterior computes the full solution on the FEM grid using a Firedrake function
-ls.solve_posterior(muy)
+# the scale_mean option will ensure that the output is scaled to match
+# the data rather than the FEM soltuion
+
+ls.solve_posterior(muy, scale_mean=True)
 
 # covariance can only be computed for a select number of locations as covariance is a dense matrix
 # function returns the mean/covariance as numpy arrays, not Firedrake functions
+
 muy2, Cuy = ls.solve_posterior_covariance()
 
 # visualize posterior FEM solution and uncertainty
@@ -124,7 +128,7 @@ muy2, Cuy = ls.solve_posterior_covariance()
 if makeplots:
     plt.figure()
     plt.tripcolor(mesh.coordinates.vector().dat.data[:,0], mesh.coordinates.vector().dat.data[:,1],
-                  np.exp(ls.params[0])*muy.vector().dat.data)
+                  muy.vector().dat.data)
     plt.colorbar()
     plt.scatter(x_data[:,0], x_data[:,1], c = np.diag(Cuy), cmap="Greys_r")
     plt.colorbar()

--- a/stat_fem/solving.py
+++ b/stat_fem/solving.py
@@ -6,7 +6,7 @@ For repeated use, please use the LinearSolver class
 from firedrake import COMM_SELF
 from .LinearSolver import LinearSolver
 
-def solve_posterior(A, x, b, G, data, params, ensemble_comm=COMM_SELF):
+def solve_posterior(A, x, b, G, data, params, ensemble_comm=COMM_SELF, scale_mean=False):
     """
     Solve for the FEM posterior conditioned on the data. solution is stored in the
     provided firedrake function x
@@ -18,9 +18,9 @@ def solve_posterior(A, x, b, G, data, params, ensemble_comm=COMM_SELF):
 
     ls = LinearSolver(A, b, G, data, ensemble_comm=ensemble_comm)
     ls.set_params(params)
-    ls.solve_posterior(x)
+    ls.solve_posterior(x, scale_mean)
 
-def solve_posterior_covariance(A, b, G, data, params, ensemble_comm=COMM_SELF):
+def solve_posterior_covariance(A, b, G, data, params, ensemble_comm=COMM_SELF, scale_mean=False):
     """
     solve for conditioned fem plus covariance in the data space
 
@@ -35,7 +35,7 @@ def solve_posterior_covariance(A, b, G, data, params, ensemble_comm=COMM_SELF):
 
     ls = LinearSolver(A, b, G, data, ensemble_comm=ensemble_comm)
     ls.set_params(params)
-    return ls.solve_posterior_covariance()
+    return ls.solve_posterior_covariance(scale_mean)
 
 def solve_prior_covariance(A, b, G, data, ensemble_comm=COMM_SELF):
     """
@@ -68,7 +68,7 @@ def solve_posterior_generating(A, b, G, data, params, ensemble_comm=COMM_SELF):
     ls.set_params(params)
     return ls.solve_posterior_generating()
 
-def predict_mean(A, b, G, data, params, coords, ensemble_comm=COMM_SELF):
+def predict_mean(A, b, G, data, params, coords, ensemble_comm=COMM_SELF, scale_mean=True):
     """
     predict mean data values at unmeasured locations
 
@@ -80,7 +80,7 @@ def predict_mean(A, b, G, data, params, coords, ensemble_comm=COMM_SELF):
 
     ls = LinearSolver(A, b, G, data, ensemble_comm=ensemble_comm)
     ls.set_params(params)
-    return ls.predict_mean(coords)
+    return ls.predict_mean(coords, scale_mean)
 
 
 def predict_covariance(A, b, G, data, params, coords, unc, ensemble_comm=COMM_SELF):

--- a/stat_fem/tests/helper_funcs.py
+++ b/stat_fem/tests/helper_funcs.py
@@ -195,7 +195,7 @@ def interp_predict(meshcoords, coords_predict):
 
 @pytest.fixture
 def params():
-    return np.zeros(3)
+    return np.array([-0.9, 0.1, -0.5])
 
 @pytest.fixture
 def Ks(od, params):

--- a/stat_fem/tests/test_LinearSolver.py
+++ b/stat_fem/tests/test_LinearSolver.py
@@ -76,7 +76,7 @@ def test_solve_posterior_parallel(my_ensemble, fs, A, b, meshcoords, fc, od, int
     u_f = u.vector().gather()
 
     u_scaled = Function(fs)
-    ls.solve_posterior(u_scaled, scale_mean=True)
+    ls_parallel.solve_posterior(u_scaled, scale_mean=True)
     u_f_scaled = u_scaled.vector().gather()
     
     rho = np.exp(params[0])

--- a/stat_fem/tests/test_LinearSolver.py
+++ b/stat_fem/tests/test_LinearSolver.py
@@ -327,15 +327,17 @@ def test_predict_covariance(fs, A, b, meshcoords, fc, od, interp, Ks, params, co
 def test_LinearSolver_logposterior(A, b, fc, od, params, Ks, ls):
     "test the loglikelihood method"
 
+    rho = np.exp(params[0])
+    
     mu, Cu = ls.solve_prior()
 
     loglike_actual = ls.logposterior(params)
 
     if COMM_WORLD.rank == 0:
-        KCu = Cu + Ks
-        loglike_expected = 0.5*(np.linalg.multi_dot([od.get_data() - mu,
+        KCu = rho**2*Cu + Ks
+        loglike_expected = 0.5*(np.linalg.multi_dot([od.get_data() - rho*mu,
                                                      np.linalg.inv(KCu),
-                                                     od.get_data() - mu]) +
+                                                     od.get_data() - rho*mu]) +
                                 np.log(np.linalg.det(KCu)) +
                                 od.get_n_obs()*np.log(2.*np.pi))
     else:
@@ -362,6 +364,6 @@ def test_LinearSolver_logpost_deriv(A, b, fc, od, params, Ks, ls):
     loglike_deriv_fd[2] = (ls.logposterior(params + np.array([0., 0., dx])) -
                            ls.logposterior(params                         ))/dx
 
-    assert_allclose(loglike_deriv_actual, loglike_deriv_fd, atol=1.e-5, rtol=1.e-5)
+    assert_allclose(loglike_deriv_actual, loglike_deriv_fd, atol=1.e-6, rtol=1.e-6)
 
 gc.collect()


### PR DESCRIPTION
Adds the ability to control scaling of the mean function output by the model discrepancy scaling factor with a `scale_mean` option on the posterior and prediction methods of `LinearSolver`. Defaults were set to maintain the previous behavior (posteriors are assumed to be the FEM solution; predictions are assumed to be scaled to the data) but can now be
controlled by the user. Updates the Poisson example to use this option. Also fixes a bug identified when writing tests for the scaling functionality. Addresses issues #13 and #35.

Changes:

* Adds `scale_mean` option to `LinearSolver.solve_posterior`, `LinearSolver.solve_posterior_covariance`, and `LinearSolver.predict_mean`. Defaults are set based on previous behavior.
* Standalone solving functions also allow the scaling option.
* Fixes an error in the `LinearSolver.logpost_deriv` method to correctly compute the negative log posterior gradient.
* Unit tests of the new and fixed functionality
* Updates to the `poisson.py` example to use the scaling option.