### PR TITLE
Fix setup.py and assembly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 MAJOR = 0
 MINOR = 3
 MICRO = 0
-PRERELEASE = 1
+PRERELEASE = 2
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setuptools.setup(name='stat_fem',
       author='Alan Turing Institute Research Engineering Group',
       author_email='edaub@turing.ac.uk',
       packages=setuptools.find_packages(),
-      license=['LGPLv3'],
+      license='LGPLv3',
       install_requires=['numpy', 'scipy'])

--- a/stat_fem/assemble.py
+++ b/stat_fem/assemble.py
@@ -1,78 +1,25 @@
 from .ForcingCovariance import ForcingCovariance
 from .InterpolationMatrix import InterpolationMatrix
-import firedrake.assemble
 
-def assemble(f, tensor=None, bcs=None, form_compiler_parameters=None,
-             mat_type=None, sub_mat_type=None,
-             appctx={}, options_prefix=None, **kwargs):
+def assemble(f):
     """
-    Overloaded assembly function to include assembly of stat-fem operators
+    Assembly function provided for assembling ``stat-fem`` PETSc matrices
+    
+    Functional interface to assembling PETSc matrices needed for the ``stat-fem``
+    solves. Note that this is just for convenience and simply calls the ``assemble``
+    method of the provided object. Note that if the matrices are not assembled
+    when they are required, ``stat-fem`` will assemble them automatically.
 
-    This provides a functional interface to assemblying stat-fem objects in the
-    same manner as other matrices and vectors in Firedrake. If the input object
-    is a ``ForcingCovariance`` or ``InterpolationMatrix`` object, it calls the
-    ``assemble`` method and returns. Otherwise, it passes the arguments along
-    to Firedrake for assembly.
-
-    If f is a :class:`~ufl.classes.Form` then this evaluates the corresponding
-    integral(s) and returns a :class:`float` for 0-forms, a
-    :class:`.Function` for 1-forms and a :class:`.Matrix` or :class:`.ImplicitMatrix`
-    for 2-forms.
-
-    If f is an expression other than a form, it will be evaluated
-    pointwise on the :class:`.Function`\s in the expression. This will
-    only succeed if all the Functions are on the same
-    :class:`.FunctionSpace`.
-
-    If f is a Slate tensor expression, then it will be compiled using Slate's
-    linear algebra compiler.
-
-    If ``tensor`` is supplied, the assembled result will be placed
-    there, otherwise a new object of the appropriate type will be
-    returned.
-
-    If ``bcs`` is supplied and ``f`` is a 2-form, the rows and columns
-    of the resulting :class:`.Matrix` corresponding to boundary nodes
-    will be set to 0 and the diagonal entries to 1. If ``f`` is a
-    1-form, the vector entries at boundary nodes are set to the
-    boundary condition values.
-
-    :param f: a :class:`~stat_fem.ForcingCovariance`, :class:`~stat_fem.InterpolationMatrix`,
-       :class:`~ufl.classes.Form`, :class:`~ufl.classes.Expr` or :class:`~slate.TensorBase`
-       expression.
-    :param tensor: an existing tensor object to place the result in
-      (optional).
-    :param bcs: a list of boundary conditions to apply (optional).
-    :param form_compiler_parameters: (optional) dict of parameters to pass to
-      the form compiler.  Ignored if not assembling a
-      :class:`~ufl.classes.Form`.  Any parameters provided here will be
-      overridden by parameters set on the :class:`~ufl.classes.Measure` in the
-      form.  For example, if a ``quadrature_degree`` of 4 is
-      specified in this argument, but a degree of 3 is requested in
-      the measure, the latter will be used.
-    :param mat_type: (optional) string indicating how a 2-form (matrix) should be
-      assembled -- either as a monolithic matrix ('aij' or 'baij'), a block matrix
-      ('nest'), or left as a :class:`.ImplicitMatrix` giving matrix-free
-      actions ('matfree').  If not supplied, the default value in
-      ``parameters["default_matrix_type"]`` is used.  BAIJ differs
-      from AIJ in that only the block sparsity rather than the dof
-      sparsity is constructed.  This can result in some memory
-      savings, but does not work with all PETSc preconditioners.
-      BAIJ matrices only make sense for non-mixed matrices.
-    :param sub_mat_type: (optional) string indicating the matrix type to
-      use *inside* a nested block matrix.  Only makes sense if
-      ``mat_type`` is ``nest``.  May be one of 'aij' or 'baij'.  If
-      not supplied, defaults to ``parameters["default_sub_matrix_type"]``.
-    :param appctx: Additional information to hang on the assembled
-      matrix if an implicit matrix is requested (mat_type "matfree").
-    :param options_prefix: PETSc options prefix to apply to matrices.
+    :param f: a :class:`~stat_fem.ForcingCovariance` or :class:`~stat_fem.InterpolationMatrix`
+    :type f: ForcingCovariance or InterpolationMatrix
+    :returns: Assembled object of the appropriate type.
     """
 
     if isinstance(f, (ForcingCovariance, InterpolationMatrix)):
         f.assemble()
         return f
     else:
-        return firedrake.assemble(f, tensor, bcs, form_compiler_parameters,
-                                  mat_type, sub_mat_type, appctx, options_prefix, **kwargs)
+        raise NotImplementedError("The stat-fem assemble function no longer supports assembling " +
+                                  "Firedrake objects. Use the firedrake assemble function directly")
 
 

--- a/stat_fem/tests/test_assemble.py
+++ b/stat_fem/tests/test_assemble.py
@@ -59,9 +59,7 @@ def test_assemble_firedrake(fs):
     u = TrialFunction(fs)
     v = TestFunction(fs)
     a = (dot(grad(v), grad(u))) * dx
-    bc = DirichletBC(fs, 0., "on_boundary")
-    A = assemble(a, bcs = bc)
-
-    assert isinstance(A, Matrix)
+    with pytest.raises(NotImplementedError):
+        assemble(a)
 
 gc.collect()


### PR DESCRIPTION
This PR fixes a problem in the setup.py file to correct license problem due to upstream change in setuptools, and removes Firedrake assembly as an option with the `assemble` function. Otherwise no significant changes.

Changes in this PR:

- Minor change to `setup.py` file.
- Remove Firedrake options from `assemble.py`